### PR TITLE
feat: 홈/히스토리 화면 Todo 리스트에 페이지네이션 적용 (#18)

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -18,6 +18,7 @@ declare module 'vue' {
     HistoryToolbar: typeof import('./src/components/todo/history/HistoryToolbar.vue')['default']
     IconButton: typeof import('./src/components/ui/IconButton.vue')['default']
     PageHeader: typeof import('./src/components/common/PageHeader.vue')['default']
+    Pagination: typeof import('./src/components/ui/Pagination.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SortToggle: typeof import('./src/components/todo/common/SortToggle.vue')['default']

--- a/src/components/todo/common/TodoList.vue
+++ b/src/components/todo/common/TodoList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import TodoSummary from "@/components/todo/home/TodoSummary.vue"
 import SortToggle from "@/components/todo/common/SortToggle.vue"
+import Pagination from "@/components/ui/Pagination.vue"
 import type { SortOrder } from "@/types/todo"
 
 const props = withDefaults(
@@ -9,6 +10,11 @@ const props = withDefaults(
     total: number
     emptyText?: string
     sortOrder?: SortOrder
+    page?: number
+    totalPages?: number
+    canPrev?: boolean
+    canNext?: boolean
+    rangeText?: string
   }>(),
   {
     emptyText: "할 일이 없습니다.",
@@ -17,6 +23,9 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: "toggle-sort"): void
+  (e: "set-page", page: number): void
+  (e: "prev-page"): void
+  (e: "next-page"): void
 }>()
 </script>
 
@@ -45,5 +54,17 @@ const emit = defineEmits<{
     >
       {{ emptyText }}
     </p>
+
+    <Pagination
+      v-if="total > 0 && (totalPages ?? 1) > 1"
+      :current-page="page ?? 1"
+      :total-pages="totalPages ?? 1"
+      :can-prev="canPrev ?? false"
+      :can-next="canNext ?? false"
+      :range-text="rangeText ?? ''"
+      @set="emit('set-page', $event)"
+      @prev="emit('prev-page')"
+      @next="emit('next-page')"
+    />
   </section>
 </template>

--- a/src/components/todo/history/TodoListHistory.vue
+++ b/src/components/todo/history/TodoListHistory.vue
@@ -4,8 +4,9 @@ import type { Todo } from "@/types/todo"
 import TodoList from "@/components/todo/common/TodoList.vue"
 import HistoryToolbar from "./HistoryToolbar.vue"
 import TodoItemHistory from "./TodoItemHistory.vue"
-import { useSortOrder } from "@/composables/useSortOrder"
 import { sortTodos } from "@/utils/sortTodos"
+import { useSortOrder } from "@/composables/useSortOrder"
+import { usePagination } from "@/composables/usePagination"
 
 const props = defineProps<{ todos: Todo[] }>()
 const emit = defineEmits<{
@@ -19,6 +20,14 @@ const { sortOrder, toggleSortOrder } = useSortOrder("desc")
 const sortedTodos = computed(() => sortTodos(props.todos, sortOrder.value))
 
 const selectedIds = ref<Set<Todo["id"]>>(new Set())
+
+const { pagedItems, currentPage, totalPages, canPrev, canNext, rangeText, setPage, prev, next } =
+  usePagination<Todo>(sortedTodos, {
+    pageSize: 10,
+    resetPageOnItemsChange: true,
+  })
+
+watch(sortOrder, () => setPage(1))
 
 watch(
   () => props.todos.map((t) => t.id),
@@ -72,6 +81,14 @@ const purgeAll = () => {
     empty-text="보관된 할 일이 없습니다."
     :sort-order="sortOrder"
     @toggle-sort="toggleSortOrder"
+    :page="currentPage"
+    :total-pages="totalPages"
+    :can-prev="canPrev"
+    :can-next="canNext"
+    :range-text="rangeText"
+    @set-page="setPage"
+    @prev-page="prev"
+    @next-page="next"
   >
     <template #toolbar>
       <HistoryToolbar
@@ -85,7 +102,7 @@ const purgeAll = () => {
     </template>
 
     <TodoItemHistory
-      v-for="todo in sortedTodos"
+      v-for="todo in pagedItems"
       :key="todo.id"
       :todo="todo"
       :selected="selectedIds.has(todo.id)"

--- a/src/components/todo/home/TodoListHome.vue
+++ b/src/components/todo/home/TodoListHome.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed } from "vue"
+import { computed, watch } from "vue"
 import type { EditTodoPayload, Todo } from "@/types/todo"
 import TodoList from "@/components/todo/common/TodoList.vue"
 import TodoItemHome from "./TodoItemHome.vue"
 import { sortTodos } from "@/utils/sortTodos"
 import { useSortOrder } from "@/composables/useSortOrder"
+import { usePagination } from "@/composables/usePagination"
 
 const props = defineProps<{
   todos: Todo[]
@@ -20,6 +21,14 @@ const emit = defineEmits<{
 
 const { sortOrder, toggleSortOrder } = useSortOrder("desc")
 const sortedTodos = computed(() => sortTodos(props.todos, sortOrder.value))
+
+const { pagedItems, currentPage, totalPages, canPrev, canNext, rangeText, setPage, prev, next } =
+  usePagination<Todo>(sortedTodos, {
+    pageSize: 10,
+    resetPageOnItemsChange: true,
+  })
+
+watch(sortOrder, () => setPage(1))
 </script>
 
 <template>
@@ -28,9 +37,17 @@ const sortedTodos = computed(() => sortTodos(props.todos, sortOrder.value))
     :total="total"
     :sort-order="sortOrder"
     @toggle-sort="toggleSortOrder"
+    :page="currentPage"
+    :total-pages="totalPages"
+    :can-prev="canPrev"
+    :can-next="canNext"
+    :range-text="rangeText"
+    @set-page="setPage"
+    @prev-page="prev"
+    @next-page="next"
   >
     <TodoItemHome
-      v-for="todo in sortedTodos"
+      v-for="todo in pagedItems"
       :key="todo.id"
       :todo="todo"
       @toggle-done="emit('toggle-done', $event)"

--- a/src/components/ui/Pagination.vue
+++ b/src/components/ui/Pagination.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { computed } from "vue"
+
+const props = withDefaults(
+  defineProps<{
+    currentPage: number
+    totalPages: number
+    canPrev: boolean
+    canNext: boolean
+    rangeText?: string
+  }>(),
+  { rangeText: "" },
+)
+
+const emit = defineEmits<{
+  (e: "prev"): void
+  (e: "next"): void
+  (e: "set", page: number): void
+}>()
+
+// 기능 확장 시 축약(ellipsis)형 페이지네이션 수정 예정
+// 현재 텍스트 버튼 형태 이전 다음, 아이콘 추가 예정
+
+const pages = computed(() => Array.from({ length: props.totalPages }, (_, i) => i + 1))
+
+const navBtnBase =
+  "rounded-md border border-neutral-800 bg-neutral-900 px-2 py-1 transition hover:bg-neutral-800 disabled:cursor-default disabled:opacity-40"
+
+const pageBtnBase =
+  "min-w-8 rounded-md border px-2 py-1 transition disabled:cursor-default disabled:opacity-60"
+const pageBtnActive = "border-neutral-600 bg-neutral-800 text-neutral-100"
+const pageBtnIdle = "border-neutral-800 bg-neutral-900 text-neutral-300 hover:bg-neutral-800"
+</script>
+
+<template>
+  <nav
+    v-if="totalPages > 1"
+    class="flex items-center justify-between gap-3 pt-2 text-sm text-neutral-300"
+    aria-label="Pagination"
+  >
+    <!-- left -->
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        :class="navBtnBase"
+        aria-label="Previous page"
+        :disabled="!canPrev"
+        @click="emit('prev')"
+      >
+        Prev
+      </button>
+
+      <button
+        type="button"
+        :class="navBtnBase"
+        aria-label="Next page"
+        :disabled="!canNext"
+        @click="emit('next')"
+      >
+        Next
+      </button>
+      <span v-if="rangeText" class="ml-2 text-neutral-400">{{ rangeText }}</span>
+    </div>
+
+    <!-- right -->
+    <div class="flex flex-wrap items-center justify-end gap-1">
+      <button
+        v-for="p in pages"
+        :key="p"
+        type="button"
+        :disabled="p === currentPage"
+        :class="[pageBtnBase, p === currentPage ? pageBtnActive : pageBtnIdle]"
+        :aria-current="p === currentPage ? 'page' : undefined"
+        @click="emit('set', p)"
+      >
+        {{ p }}
+      </button>
+    </div>
+  </nav>
+</template>

--- a/src/composables/usePagination.ts
+++ b/src/composables/usePagination.ts
@@ -1,0 +1,96 @@
+import { computed, ref, unref, watch, type ComputedRef, type Ref } from "vue"
+
+type UsePaginationOptions = {
+  pageSize?: number
+  resetPageOnItemsChange?: boolean
+}
+
+// Ref<T[]> 또는 ComputedRef<T[]> 둘 다 받기
+type ListSource<T> = Ref<T[]> | ComputedRef<T[]>
+
+export type UsePaginationReturn<T> = {
+  // state
+  pageSize: Ref<number>
+  currentPage: Ref<number>
+  totalPages: ComputedRef<number>
+  total: ComputedRef<number>
+
+  // derived
+  pagedItems: ComputedRef<T[]>
+  canPrev: ComputedRef<boolean>
+  canNext: ComputedRef<boolean>
+  rangeText: ComputedRef<string>
+
+  // actions
+  setPage: (page: number) => void
+  prev: () => void
+  next: () => void
+}
+
+export function usePagination<T>(
+  items: ListSource<T>,
+  options: UsePaginationOptions = {},
+): UsePaginationReturn<T> {
+  const pageSize = ref(options.pageSize ?? 10)
+  const currentPage = ref(1)
+
+  const total = computed(() => unref(items).length)
+  const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize.value)))
+
+  const startIndex = computed(() => (currentPage.value - 1) * pageSize.value)
+  const endIndex = computed(() => startIndex.value + pageSize.value)
+
+  const pagedItems = computed<T[]>(() => unref(items).slice(startIndex.value, endIndex.value))
+
+  const canPrev = computed(() => currentPage.value > 1)
+  const canNext = computed(() => currentPage.value < totalPages.value)
+
+  const setPage = (page: number) => {
+    const safe = Math.min(Math.max(1, page), totalPages.value)
+    currentPage.value = safe
+  }
+  const prev = () => setPage(currentPage.value - 1)
+  const next = () => setPage(currentPage.value + 1)
+
+  // items 길이가 줄어서 currentPage가 유효 범위를 벗어나는 경우 보정
+  watch([totalPages, pageSize], () => {
+    if (currentPage.value > totalPages.value) currentPage.value = totalPages.value
+  })
+
+  // 아이템 변화 시 page=1 리셋 (정렬/필터 포함)
+  if (options.resetPageOnItemsChange ?? true) {
+    watch(
+      () => unref(items),
+      () => {
+        currentPage.value = 1
+      },
+      { deep: false },
+    )
+  }
+
+  const rangeText = computed(() => {
+    if (total.value === 0) return "0"
+    const from = startIndex.value + 1
+    const to = Math.min(endIndex.value, total.value)
+    return `${from}-${to} / ${total.value}`
+  })
+
+  return {
+    // state
+    pageSize,
+    currentPage,
+    totalPages,
+    total,
+
+    // derived
+    pagedItems,
+    canPrev,
+    canNext,
+    rangeText,
+
+    // actions
+    setPage,
+    prev,
+    next,
+  }
+}

--- a/src/composables/usePagination.ts
+++ b/src/composables/usePagination.ts
@@ -31,7 +31,7 @@ export function usePagination<T>(
   items: ListSource<T>,
   options: UsePaginationOptions = {},
 ): UsePaginationReturn<T> {
-  const pageSize = ref(options.pageSize ?? 10)
+  const pageSize = ref(Math.max(1, options.pageSize ?? 10))
   const currentPage = ref(1)
 
   const total = computed(() => unref(items).length)


### PR DESCRIPTION
## 요약

- Home 화면과 History 화면 Todo 리스트에 페이지네이션 기능을 공통 적용했습니다.

## 미리보기
<img width="3024" height="2144" alt="image" src="https://github.com/user-attachments/assets/98da1b46-3a91-49e4-b480-3990854ff025" />

## 관련 이슈

- closes #18

## 변경 내용

- 공통 페이지네이션 composable(usePagination) 추가
- Pagination UI 컴포넌트 추가
- Home Todo 리스트에 페이지네이션 적용
- History Todo 리스트에 페이지네이션 적용
- 페이지당 10개 항목 표시
- 정렬 기능과 페이지네이션 연동
- 이전/다음 및 페이지 번호 네비게이션 추가
- 관련 타입 및 컴포넌트 props 업데이트

## 테스트

- [ ] Home 화면에서 페이지 이동 정상 동작 확인
- [ ] History 화면에서 페이지 이동 정상 동작 확인
- [ ] 정렬 변경 시 1페이지로 리셋되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side pagination for the todo list with 10 items per page and page navigation
  * Pagination controls: previous, next, and direct page selection buttons, plus range display
  * Page resets automatically when sort order changes
  * Pagination available in both main and history views and exposed as a reusable UI control and pagination utility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->